### PR TITLE
[DECKS-646] Prevent wait mechanism from querying events too early

### DIFF
--- a/Sources/SwiftCoreData/initialization/NSPersistentCloudKitContainer+Extensions.swift
+++ b/Sources/SwiftCoreData/initialization/NSPersistentCloudKitContainer+Extensions.swift
@@ -86,6 +86,11 @@ extension NSPersistentCloudKitContainer {
     request.resultType = .events
     request.affectedStores = affectedStores
     
+    // Initial delay to allow SQLite to propagate initialization if needed.
+    // NOTE: Needed since we are querying for events from the container and that table needs
+    //       to have been created first.
+    try await Task.sleep(seconds: pollIntervalSeconds)
+    
     // Poll for events, checking import status.
     // NOTE: Task closure is executed on the main actor so that it can have access to the
     //       `viewContext` of the container.


### PR DESCRIPTION
On initial installs SQLite takes a bit of time to propagate table creation. Querying the table too early causes a SQLite error and causes the entire app start up to freeze. We will wait for one polling interval for initialization to propagate.

Works on xiiagency/Decks#646